### PR TITLE
Add a talk from 1970, and talks from the first half of 1986

### DIFF
--- a/static/talks.yaml
+++ b/static/talks.yaml
@@ -11928,3 +11928,254 @@
     Suppose T is a finite limit theory, G a T-algebra then elG is a theory called the many sorted theory of T with algebra of sorts G. ElG-algebras correspond (via el left adjoint to Fam) to T-algebras in FamC whose projection onto C is G; similarly elG-coalgebras (co-many-sorted T-algebras) correspond to T-algebras in Fam(C^op). Every T-algebra is trivially an elG-algebra and any elG-algebra K yields a T-algebra F via Kan extension which is given on objects T ∈ T by F(T) = ΣKx x ∈ GT (forget that the G-Indexed sorts are different).
 
     Moore's domains are a co-many-sorted category in Top, so homming into X gives a many sorted category whose associated ordinary category is the Moore category on X. Similarly the free monoid on a set and the free category on a dirccted graph result from homming out of co-many-sorted monoid and category objects in Set and Grph respectively, and the collection of well formed simplicial complexes form a co—many-sorted ω-category in the category of simplicial sets.
+- id: 1778
+  title: Preservation of Finite Connected Limits
+  speaker: Robert Paré
+  date: 1986-02-26T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Proposition 1. A category has finite connccted limits iff it has pullbacks and equalizers. Proposition 2. A functor between finitely complete categories preserves finite comnected limits if it preserves pullbacks. Example. Categories A and B have finite connected limits and F: A → B preserves pullbacks but doesn't preserve equalizers. (Let f:H→G be a non one-one group homomorphism. Build a category G out of G by considering it as a one object category and formally adjoining an initial object. Do the same for H and define a functor in the obvious way. This last mentioned functor is an example of the above.) Question: Why are the finite limits needed in proposition 2? Or rather, what is the A and B have limits of finite connected diagrams which admit a cocone, then F preserves these iff F preserves pullbacks.
+- id: 1779
+  title: Logic and Factorization Systems I.
+  speaker: G. Munro
+  date: 1986-02-26T15:15:00.000Z
+  location: Sydney
+  abstract: |-
+    Start with a category with finite limits and a factorization system (E,M) satisfying; Property E: an arbitrary pullback of a morphism in E is again in E and, Property M: M contains the monomorphisms. Call such a category an EM-category. These have a natural logic, a restricted predicate calculus with "and", "there exists", = as logical operators. The interpretation is as usual, but with predicates interpreted as arrows in M. Leading example: an elementary topos with a topology; E consists of epimorphisms composed with j-dense monomorphisms, M consists of j-closed monomorphisms.
+- id: 1780
+  title: The Finer Structure of Cubes
+  speaker: Iain Aitchinson
+  date: 1986-03-05T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    An inductive geometric definition of k-dimensional source and target for an n-cube is described. Viewed as functions n = {1,2,...,n} → Λ = {-,0,+}, the subcubes of the n-cube can be interpreted as words of length n in {-,0,+}. The sources and targets of the n-cube arise as particular "k-blocks in Λ^n", where a "0-block" is an element of Λ^n, and we inductively define a k-block, k odd (resp. even) is a column (resp. row) of (k-1)-blocks. The sources $\theta_k(n)$, $\tau_k(n)$ of dimensions k of the n-cube can be defined inductively by the maps $\lambda_k, \nu_k, \mu_k : B_n^k \to B_{n + 1}^k, B_{n + 1}^k, B_{n + 1}^{k + 1}$ respectively, where $B_n^k$ is the set of k-blocks in Λ^n. Cocycle conditions for an n-category structure can be defined which correspond naturally to the cocycles discovered by Street in his work on orientals.
+- id: 1781
+  title: Report on Work done while on Leave.
+  speaker: Robert Walters
+  date: 1986-03-05T15:15:15.000Z
+  location: Macquarie
+  abstract: |-
+    While I was on leave (June 85–Aug 85 in USA, England and Italy; Oct 85–Jan 86 in Italy) I wrote two papers: 1) An Axiomatics for Bicategories of Modules (with A. Carboni and S. Kasangian), and 2) On Completeness of Locally-Internal Categories (with R. Betti). Both are to appear in JPAA. In the lecture I gave a brief discussion of the contents. I also suggested that we should produce "Abstracts of the Sydney Category Seminar". There was discussion resulting in general agreement. Michael offered to set this up.
+- id: 1782
+  title: Banach Algebras as Enriched Categorics
+  speaker: Barry Jay
+  date: 1986-03-05T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    A normed abelian group $(A, |\ |)$ is an abelian group A together with a monoidal functor $|\ | \colon A \to R^+$ (see Lawvere's Metric Spaces paper) (ie $|a + b| \leq |a| + |b|$, $|0| \leq 0$) satisfying further $|-a| = |a|$. Morphisms of these are norm-reducing group homomorphisms. The category is called Nab. Theorem 1: There is a forgetful fusctor $U : Nab - Met$ (= Metric spaces) which is monadic. Proof: $F(x,d)=(F'X, |\ |)$ where $F'X$ is the free abelian group in X. The norm is generated by $|x-y| = d(xy)$. □ A normed R-algebra is an R-algebra R together with an abelian group norm satisfying $|xy| \leq |x| . |y|$, $|rx| \leq |r| . |x|$ $r \in R$, $|1| \leq 1$. The morphisms are norm-reducing R-algebra homomorphisms; the category is $NR^+$alg. Theorem 2: $NR$-alg → Met is monadic. By cauchy-completing we get the corollary that Banach algebras are monadic over complete metric spaces.
+- id: 1783
+  title: Introduction To Accessible Categories.
+  speaker: Robert Paré
+  date: 1986-03-05T16:10:00.000Z
+  location: Sydney
+  abstract: |-
+    Some basic facts on $\kappa$—filtered colimits were reviewed. Right $\kappa$-filtered profunctors were introduced, and a number of their properties given. A $\kappa$-accessible category was defined to be a category for which there existed a small set of $\kappa$-presentable objects of which every object was a $\kappa$—filtered colimit. Homework: show that every small category with split idempotents is $\kappa$-accessible for some $\kappa$.
+- id: 1784
+  title: Accessible Categories (ct'd)
+  speaker: Robert Paré
+  date: 1986-03-12T15:00:00.000Z
+  location: Sydney
+  abstract: |-
+    It was shown that the 2-category of $\kappa$-accessible categories, $\kappa$-accessible functors and natural transformations is biequivalent to the bicategory of small functors, right $\kappa$-flat profunctors, and natural transformations. This followed from the fact that a $\kappa$-accessible category is equivalent to the category of flat functors from a small category into Set. Also, last week's homework problem was worked out in detail.
+- id: 1784
+  title: Logic and Factorization Systems II.
+  speaker: G. Monro
+  date: 1986-03-12T16:15:00.000Z
+  location: Sydney
+  abstract: |-
+    If T is a theory based on the restricted logic, we construct a category $C_T$ whose objects are formulae and whose arrows are (equivalence classes of) n-tuples of terms in the theory. (This is different from the construction of Makkai and Reyes.) $C_T$ is an EM-category and can be used to show that if a sequent is true in all EM-categories which are models of T, then the sequent is a theorem of T (completeness theorem). A proof using Boolean-valued models shows that the classical predicate calculus is a conservative extension of the restricted logic. A relation in an EM-category A is $R \to AB$, where the arrow is in M. A functional relation is one satisfying r(a,b)&r(a,b') b=b' and b r(a,b). There is a category $A_{fr}$, with arrows functional relations, which is regular, and a left exact functor $\Lambda \colon A \to A_{fr}$. Define an object A in an EM-category to be separated if the diagonal $\Delta \colon A \to AA$ is in M and complete if for every functional relation $r : B \to A$ there is a unique morphism $f : B \to A$ such that $\Lambda(f) = r$. Separated (resp. complete) objects enjoy some (but not all) of the properties that separated presheaves (resp. sheaves) have in a category of presheaves.
+- id: 1785
+  title: Sketches and Accessible Categories
+  speaker: Robert Paré
+  date: 1986-03-19T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    The definition of sketch (Ehresmann) was reviewed and it was shown that categories of models of sketches in Set are exactly the accessible categories. This was then used to prove that Acc $\subset$ Set is closed under weighted limits of retract type.
+- id: 1786
+  title: Some Parametrized Catcgorical Concepts I
+  speaker: Ross Street
+  date: 1986-03-19T15:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    A category parametrized by a category C was taken to merely be a functor $\partial \colon A \to C$. Categorical matters to do with limits were claimed to do with cartesian cones in A. The existence of enough cartesian cones includes the fibration condition and completeness of fibres with respect to stable limits. Monics also have to do with limits and so we get a notion of parametric monic in A. This leads to a natural notion of wellpoweredness for parametrized categories.
+- id: 1787
+  title: A Tensor Product of Symmetric Monoidal Categories.
+  speaker: Barry Jay
+  date: 1986-03-19T17:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    A tensor product of symmetric monoidal categories. A tensor product of symmetric monoidal categories $A \square B$ is introduced with the universal property strict : $A \square B \to C$ is in bijection with $A \to$ SMon(B, C) where $F = (F, F', F'')$ is strict if F' and F'' are identities and Smon(B,C) is the (symmetric monoidal) category of symmetric monoidal functors from A to C. More formally, there is an adjunction $- \square B$ left adjoint to SMon(B,-): SMon_strict -> SMon. A related adjunction is $- \square' B$ left adjoint to SMon_strongmaps(B, -) : SMon_strict -> SMon_strong. Replacing strict morphisms by strong morphisms we get an equivalence between SMon_strong(A \square' B, C) and SMon_string(A, SMon_strong(B, C)). This $\square'$ gives a monoidal struciure for SMon_strong. A semi-ring is a symmetric monoidal cat V with a strong map $V \square' V \to V$ satisfying the appropriate conditions. Then V may be used to replace $R^+$ in the construction of Banach algebras as in last weeks talk.
+- id: 1788
+  title: A Letter From Max To Ross, McGill 15/3/86
+  speaker: Ross Street
+  date: 1986-04-02T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    The letter discusses: 1) Wood's work on proarrows. 2) Resemblence of i : T-Alg -> T-Alg to Wood's situation which suggests the question of the adjoint to i. 3) Kan arrows in Street–Walters sense. 4) Does W left adjoint to Z left adjoint to Y imply A isomorphic to [B^op, Set] where Y is yoneda for A. (Remark: R. Walters believes locales give a counterexample to this.)
+- id: 1789
+  title: Many Sorted Algebras and the Moore Construction.
+  speaker: Michael Johnson
+  date: 1986-04-02T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Section titles: 1) Motivation 2) Many sorted algebras 3) Theory of many sorted algebras 3) Examples.
+- id: 1790
+  title: Logic and Factorization Systems III.
+  speaker: G. Monro
+  date: 1986-04-09T16:30:00.000Z
+  location: Macquarie
+  abstract: |-
+    Let A be an EM-category and A an object of A. A power object of A in A is an object PA together with a relation $\epsilon_A : PA \to A$ such that for every relation r : X -> A there is a unique morphism f : X -> PA such that $r = \epsilon_A^\circ\Lambda(f)$. If every object has a power object we call A a near-topos. The full higher-order logic of topoi can be interpreted in a near—topos, every PA is complete (proof uses higher-order logic); the complete objects form a reflective subcategory with left exact reflector and the complete objects form an elementary topos. Examples: (i) Any quasitopos, with (E,M) = (Epis, Strong Monos) (ii) Category of topological spaces, with (Epis, Subspace inclusions) (iii) Elementary topos with topology j; E = composites epi with j-dense mono, M = j-closed monos. Here the complete objects are the j-sheaves, so the result above generalizes the sheafification theorem for elementary topoi.
+- id: 1791
+  title: Reading Between the Lines of Paré's Talks
+  speaker: M. Adelman
+  date: 1986-04-09T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    What does it mean for a category to have ultra-powers? Paré, Makkai and myself seem to have independently come to the same conclusion that having ultra-powers is part of the axiomatics of a category of models of a theory written in first order logic. Preferably we should be able to state it as a diagonal functor having an adjoint as is the case with having limits and colimits. If X is a set and U is an ultrafilter on X, form a site X as follows: The underlying category is 2^X and the covers of I are finite families {J_i} so that $I = \cup J_i$. Then the characteristic function is a point of the site inducing an adjoint pair p_*, left adjoint to p^* : Shv( X ) -> Set. If we view p_*, as a diagonal; saying p^* exists is saying the U-ultrapower exists. If T is a coherent theory, p_* restricts to Mod(T) -> Mod(T, Shv( X )); but not in theories with negation (eg. the theory of sets with at least two elements). We seem to need Shv( X )/U for this. We loose adjoints in this construction; however perhaps this is the right thing interpreted over a different base topos other than sets, or viewed as a fibred category with a "non-standard" fibration.
+- id: 1792
+  title: Bicategorical Aspects of Representation Theory.
+  speaker: Robert Walters
+  date: 1986-04-09T15:15:00.000Z
+  location: Macquarie
+  abstract: |-
+    Many examples exist of the following phenomenon: a bicategory B (distributive and with further structure), an additive category A, and a "cardinality functor" # : B -> A. The cardinality of a finite set, the dimension of a vector space, the cardinality of a species, all fit into this pattern. I discussed the following important example. Let B be the bicategory whose objects are finite groups, arrows from G to H are finite dimensional left G, right H modules. Let A be the additive category with objects same as B, but arrows from G to H are class functions G $\times$ H -> C. Then the character of a representation provides a cardinality functor. (Which preserves biclosed structure, global tensor product, etc.) The fact that it preserves composition is a fundamental fact not usually stressed in standard books on group representation.
+- id: 1793
+  title: Some Parametrized Categorical Concepts II.
+  speaker: Ross Street
+  date: 1986-04-16T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Suppose $\partial$ : A - C is a fibration, A, C are finitely complete and $\partial$ is left exact. Various categories over C are defined: Mon_C(A), Hom_C(A, B), Idem_C(A). Write A_gpd for the category with the same objects as A and cartesian arrows. Call A wellpowered when each Mon_C(A)_gpd has a terminal object. Say A has small homs when each Hom_C(A,B) has a terminal object. Say A has small idempotency when each Idem_C(A) has a terminal object. Theorems: (i) Wellpowered implies Mon_C(A) is essentially small. (ii) Small homs iff small idempotency.
+- id: 1794
+  title: Standard and Nonstandard Parametrized Categories
+  speaker: M. Adelman
+  date: 1986-04-16T15:15:00.000Z
+  location: Sydney
+  abstract: |-
+    (This results from a disscussion with R. Pare while he was in Sydney) If A is any category define T(C)=[C,A] to be the standard parametrization of A. If T is a parametrized category, say T is good if T(f) has both adjoints for all f : C -> D. The standard parametrization is good iff A is complete and cocomplete. If H denotes the homotopy category the we know it is not complete. Heller has introduced an alternative parametrization. For any small category C, we form Top^C. This has a quillen model structure which gives a class of weak equivalences. We invert these and call the result H(C). Theorem (Heller): H is a good parametrization of H. Similarly: If U is a filter on a set X, we can define N(C) for each C by N = Set^C/U (filter-power of Set^C). Theorem: N is a good parametrization of Set^X/U. Both of these, N and H are non-standard parametrizations. Are they part of a general process to make a parametrization good? One feels that for A complete and cocomplete one needn't go beyond the standard parametrization. The standard parametrization of Set^X/U is not good (Adelman–Johnstone).
+- id: 1795
+  title: $A \square B$
+  speaker: Barry Jay
+  date: 1986-04-23T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Following a previous talk, a new proof is given of the existence of $A \square B$, for symmetric monoidal categories A and B. Proposition 1: SMon(A,SMon(B,C)) $\cong$ SMon(B,SMon(A,C)) 2-naturally in all variables $\square$ Note that by replacing SMon by SMon_strong or SMon_strict ie replace "all monoidal functors B -> C" by "all strong (resp. strict)..." many parallel theorems result. Proposition 2: Let $\alpha$ be a 2-cell in SMon then SMon($\alpha$, -) is defined. Theorem 3: SMon(B,-) : SMon_strict -> SMon has a left 2-adjoint $-\square B$ which is 2-natural in B. Hence $\square$ : SMon^2 -> SMon is a 2—functor. Proposition 4: i: Smon_strict(A $\square$ B,C) -> SMon(A $\square$ B,C) has a right adjoint S. Proof. S is constructed on the gencrators of A $\square$ B given in the previous lecture. Corollary 5: There are 2-natural strict monoidal functors a and a' between (A $\square$ B) $\square$ C and A $\square$ (B $\square$ C) which both satisfy the pentagon law for monoidal categories. Note 1) a and a’ are not inverse. Note 2) Prettier calculations may be made with strong monoidal functors (eg. a becomes an equivalence) but a 'norm' is not strong im general. Note 3) There is a third version of the theorem for bicategorics and homomorphisms. For morphisms of bicategories and homomorphisms. For morphisms of bicategories the naturality conditions break down.
+- id: 1796
+  title: Some Parametrized Concepts III.
+  speaker: Ross Street
+  date: 1986-04-23T15:20:00.000Z
+  location: Sydney
+  abstract: |-
+    Generators and strong gemerators for a parametrized category were defined. If A is fibred over C and has small homs we have: C^2 admits monic parts and A has a generator implies A admits monic parts. C^2 admits invertible parts and A has a strong genherator implies A admits invertible parts.
+- id: 1797
+  title: Linear Finiteness
+  speaker: M. Adelman
+  date: 1986-04-23T16:50:00.000Z
+  location: Sydney
+  abstract: |-
+    What follows arises from conversations with A. Kock. Let B be a cartesian closed category and let Vect_R(B) demote the category of R-vector spaces (=modules) in B, where R is a ring in B. The restricted double dual of an object B of B, denoted by D (B) is defined as D (B) = Hom_R(R^B,R) where Hom_R is the object of homomorphisms and R^B has its pointwise vector space structure. Evaluating gives a map k : B -> Hom_R(R^B,B), Now assume that free vector spaces exist, that is, a left adjoint to the forgetful functor Vect_R( B ). The map k above induces a homomorphism h : F(B) -> D (B). We call B linearly finite when h is an isomorphism. If B = Set and R is any field then linear finite is equivalent to finite. This needs decidability to prove. It is even interesting to ask when h is a mono. This situation doesn't cover the motivating example ie. where D (B) is distributions on B, B is a manifold, and the statement that h is an iso is Walbroek's theorem. The problem is we camnot use Vect but some form of complete vector spaces.
+- id: 1798
+  title: A $\square$ B II.
+  speaker: Barry Jay
+  date: 1986-05-07T16:30:00.000Z
+  location: Sydney
+  abstract: |-
+    (I) The right-hand associativity for $\square$ , r : A -> A $\square$ A is natural in A and satisfies the triangle law. There is a strict symmetric monoidal functor r' : a$\square$ -> A but it is not natural. (II) On generalization of the notion "monoid” is "category". Another is "monoidal category". In the same way "abelian group" becomes "additive category" or "symmetric monoidal closed category". There is a full embedding Ab -> SMon mapping A tensor B to A $\square$ B. (III) Definition. Let A be a SMC and V be SMon. Then a V-norm for A is a symmetric monoidal functor | | : A -> V satisfying the following condition, |A(A, B)| $\cong$ |A(B, A)|. |A| is the V-cat with the same objects as A but with |A|(A, B) = |A(A, B)| etc. Say | | is cauchy complete iff |A| is.
+- id: 1799
+  title: String Diagrams.
+  speaker: I. Aitchinson
+  date: 1986-05-21T15:45:00.000Z
+  location: Macquarie
+- id: 1800
+  title: Braided Monoidal Categories
+  speaker: Ross Street
+  date: 1986-05-28T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Crossed modules give rise to monoidal categories of a special kind (groups in Cat). Braidings on these monoidal categories amount to bracket operations (like abstract commutators) on crossed modules. These arise as Samelson brackets in homotopy theory $\pi_2 X \times \pi_2 X \to \pi_3 X$. In preparation for characterizing braided monoidal groupoids with each Aq- an equivalence, aspects of group cohomology were discussed.
+- id: 1801
+  title: The Foundations of Homotopy Theory
+  speaker: Robert Walters
+  date: 1986-06-11T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    I gave some motivation for my work with Mike Johnson. Our first idea is that one should study paths first and then homotopy. (Following Lavwere) we begin with a topos E. We expect that paths in an object X should have a co-category structure (paths of all dimensions). The first axiom should be that paths are represented. In examples (Sets, simplicial sets, etc.) we find that paths are in fact represented by a family of objects I -> N . The paper we are currently completing deals with the dif- ficult task of defining paths (of all dimensions) in a simplicial set and establishing the $\omega$-category structure on the paths.
+- id: 1801
+  title: Well-formed Simplicial Sets.
+  speaker: Michael Johnson
+  date: 1986-06-11T15:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    This talk presented an alternative description of Street's orientals. The description is geometric. The elements of the orientals turn out to be certain simplicial sets. A finite n-dimensional simplicial set A is called compatible if for x, y $\in$ X_n, x $\partial_i$; = y $\partial_j$, i+j even, implies x=y. A compatible simplicial set is "sensibly oriented" at its top dimension. To analyze its lower dimensions we define the domain and codomain of a simplicial set. If A is an n-dimensional simplicial set, x $\in$ A is called an end of A if there exists y $\in A_n$, {a_0, a_1, ... a_k } even integers a_0 < a_1 ... < a_k with x = y $\partial_{a_k} \partial_{a_{k - 1}} \cdots \partial_{a_0}$ (composing a la Eilenberg). The graded set of ends of A is denoted by EA). The domain of A is by definition, A-E(A). Similarly for the codomain of A (odd integers). Well formed simplicial sets are defined inductively: A zero dimensional well formed simplicial set is a singleton; an n-dimensional simplicial set is well formed if it's compatible and its domain and codomain are well formed simplicial sets. The collection of well formed simplicial sets form an $\omega$-catecgory (with union as composition).
+- id: 1802
+  title: A New Notion of Field.
+  speaker: Barry Jay
+  date: 1986-06-11T16:15:00.000Z
+  location: Macquarie
+- id: 1803
+  title: Convolution For The Working Mathematician.
+  speaker: Brian Day
+  date: 1986-06-18T14:10:00.000Z
+  location: Macquarie
+- id: 1804
+  title: Some Remarks on Group Cohomology.
+  speaker: Ross Street
+  date: 1986-06-18T15:15:00.000Z
+  location: Sydney
+  abstract: |-
+    The monoidal structure on H^*(G,-) was described. Artin–Tate periodicity was discussed with applications to the Eilenberg–Mac Lane cohomology of abelian groups.
+- id: 1804
+  title: Nerve of n-categories I.
+  speaker: M. Zaks
+  date: 1986-06-25T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    Elementary introduction to simplicial sets and the nerve of a category. I showed that simplicial sets that are nerves of categories satisfy simple extension properties and that this characterizes them.
+- id: 1805
+  title: Paths in Simplicial Sets.
+  speaker: Robert Walters
+  date: 1986-06-25T16:50:00.000Z
+  location: Macquarie
+  abstract: |-
+    Any geometric subject should begin with the correct abstract operations. To begin, we should have a category with finite limits, subobject classifiers, exponentiation. For homotopy theory we should have an object I to parametrize paths; ie paths shoud be a representble functor into $\omega$-categories. The idea is to first study this structure and later study homotopy classes of functions. In fact, work with Michael Johnson has lead to considering many sorted co-$\omega$—category objects (where the sorts form an $\omega$-category) to parametrize paths. The Moore-path category is obtained from a co-category with sorts being real intervals. The free monoid on a set arises from a co-monoid with sorts being natural numbers. In simplicial sets, Street's orientals yield a many-sorted co-$\omega$-category to parametrize paths (Johnson).
+- id: 1806
+  title: Nerve of n-categories II.
+  speaker: M. Zaks
+  date: 1986-06-02T14:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    A description of the nerve of the free omega category on 2 [Street, oriented simplices] was given. I used the notion of a shift on a simplicial set.
+- id: 1807
+  title: Paths and Omega Categories
+  speaker: Robert Walters
+  date: 1986-06-02T15:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    More on paths in simplicial sets. The new aspect of the talk was that we (Johnson, Walters) have discovered that the higher identity laws arise from the orientals - against our expectations that the identity laws have a different goometry than the associative laws.
+- id: 1808
+  title: Algebraic Structure on Enriched Categories.
+  speaker: Barry Jay
+  date: 1986-06-02T16:00:00.000Z
+  location: Macquarie
+  abstract: |-
+    A summary of the series of talks given on normed abelian groups using enriched category theory. (No abstract; comment is by editor, me!)
+- id: 1809
+  title: Paths and Omega Categories
+  speaker: Robert Walters
+  date: 1986-06-09T14:00:00.000Z
+  location: Sydney
+  abstract: |-
+    Continuation of previous lecture (11/June/1986).
+- id: 1810
+  title: Cellular Spaces
+  speaker: Samuel Eilenberg
+  date: 1986-06-09T15:00:00.000Z
+  location: Sydney
+- id: 1809
+  title: Why There Are No Loops.
+  speaker: Ross Street
+  date: 1986-06-09T16:20:00.000Z
+  location: Sydney
+  abstract: |-
+    Let M be the endomorphism monoid of 2 in Cat. Then the category of right M-sets is the category of graphs (directed, with chosen endo-edges at each vertex). Let $\omega$ = {0,1,2,...} as an ordered set. Call $\alpha \colon \omega \to \omega$ in Cat eventually consecutive when there exists k such that $\alpha(i + 1) = \alpha(i) + 1$ for all i>k. Let $\Delta$ denote the monoid of eventually constant $\alpha \colon \omega \to \omega$ under composition. The category of right $\Delta$-sets is essentially the category of simplicial sets : there can be some infinite dimension cells. (This was not the main point of the lecture.) The remainder of the lecture described O_n, giving some technicalities as to why no loops occur.

--- a/static/talks.yaml
+++ b/static/talks.yaml
@@ -11912,3 +11912,19 @@
   speaker: Richard Garner
   date: 2024-07-10T16:00:00.000Z
   location: Macquarie
+- id: 1776
+  title: Paré on tripleability of Compact Hausdorff Spaces
+  speaker: Ross Street
+  date: 1970-10-07T00:00:00.000Z
+  location: Macquarie
+- id: 1777
+  title: Many Sorted Theories Derived from not so Many Sorted Theories
+  speaker: Michael Johnson
+  date: 1986-02-05T15:00:00.000Z
+  location: Sydney
+  abstract: |-
+    The Moore-category on a space X, is an important "homming into X" construction but cannot be classically explained (Moore's domains are not a co-category object in Top). We present an analysis of the Moore construction.
+
+    Suppose T is a finite limit theory, G a T-algebra then elG is a theory called the many sorted theory of T with algebra of sorts G. ElG-algebras correspond (via el left adjoint to Fam) to T-algebras in FamC whose projection onto C is G; similarly elG-coalgebras (co-many-sorted T-algebras) correspond to T-algebras in Fam(C^op). Every T-algebra is trivially an elG-algebra and any elG-algebra K yields a T-algebra F via Kan extension which is given on objects T ∈ T by F(T) = ΣKx x ∈ GT (forget that the G-Indexed sorts are different).
+
+    Moore's domains are a co-many-sorted category in Top, so homming into X gives a many sorted category whose associated ordinary category is the Moore category on X. Similarly the free monoid on a set and the free category on a dirccted graph result from homming out of co-many-sorted monoid and category objects in Set and Grph respectively, and the collection of well formed simplicial complexes form a co—many-sorted ω-category in the category of simplicial sets.


### PR DESCRIPTION
It would be historically valuable to record all the talks that have been given at the Australian Category Seminar for which a record exists. I have added the information for a talk from 1970 ([from Bob Walters' blog](https://rfcwalters.blogspot.com/2010/08/category-seminar-in-sydney.html)) as well as all the talks from February till July 1986 (from [this scan of abstracts](https://web.archive.org/web/20170210231156/https://dl.dropboxusercontent.com/u/92056191/Archive/seminars/sydney-category-seminar-abstracts/sydney_category_seminar_1986.pdf)).

I have access to abstracts for the latter half of 1986, as well as for 1987 and 1988, which I can add when I find the time.

I tried to replicate the content of the abstracts as was most convenient. However, it would be better if the webpage was able to render LaTeX so that the abstracts could be typeset properly. I may look into this later.